### PR TITLE
Execute the `SELECT` clause on vnodes

### DIFF
--- a/include/riak_kv_ts.hrl
+++ b/include/riak_kv_ts.hrl
@@ -45,6 +45,7 @@
           col_return_types = []   :: [riak_ql_ddl:external_field_type()],
           col_names        = []   :: [binary()],
           clause           = []   :: [riak_kv_qry_compiler:compiled_select()],
+          compiled_clause  = [],
           finalisers       = []   :: [skip | function()]
         }).
 

--- a/include/riak_kv_ts.hrl
+++ b/include/riak_kv_ts.hrl
@@ -40,14 +40,18 @@
 
 -record(riak_sel_clause_v1,
         {
-          calc_type        = rows :: select_result_type(),
-          initial_state    = []   :: [any()],
-          col_return_types = []   :: [riak_ql_ddl:external_field_type()],
-          col_names        = []   :: [binary()],
-          clause           = []   :: [riak_kv_qry_compiler:compiled_select()],
-          compiled_clause  = [],
-          finalisers       = []   :: [skip | function()]
-        }).
+          calc_type = rows :: select_result_type(),
+          initial_state = [] :: [any()],
+          col_return_types = [] :: [riak_ql_ddl:external_field_type()],
+          col_names = [] :: [binary()],
+          %% the select clause AST
+          clause = []   :: [riak_kv_qry_compiler:compiled_select()],
+          %% the select clause AST compiled into funs, valid only on the node
+          %% that compiled the funs
+          compiled_clause = [],
+          finalisers = [] :: [skip | function()],
+          result_merger_fns = []
+        }). 
 
 -define(GROUP_BY_DEFAULT, []).
 -record(riak_select_v1,

--- a/rebar.config
+++ b/rebar.config
@@ -27,8 +27,8 @@
 {deps, [
         {sidejob,          ".*", {git, "https://github.com/basho/sidejob.git",        {tag,    "2.0.1"}}},
         {bitcask,          ".*", {git, "https://github.com/basho/bitcask.git",        {tag,    "2.0.6"}}},
-        {hanoidb,          "1.*", {git, "git@github.com:andytill/hanoidb.git",        {branch, "riak_tst"}}},
-        {riak_kv_hanoidb_backend, ".*", {git, "git@github.com:andytill/riak_kv_hanoidb_backend.git", "riak_tst"}},
+        {hanoidb,          "1.*",       {git, "https://github.com/andytill/hanoid.git",        {branch, "riak_tst"}}},
+        {riak_kv_hanoidb_backend, ".*", {git, "https://github.com/andytill/riak_kv_hanoidb_backend.git", {branch,"riak_tst"}}},
         {eper,             ".*", {git, "https://github.com/basho/eper.git",           {tag,    "0.97.5p1"}}},
         {sext,             ".*", {git, "https://github.com/basho/sext.git",           {tag,    "1.1p6"}}},
         {riak_pipe,        ".*", {git, "https://github.com/basho/riak_pipe.git",      {branch, "riak_ts-develop"}}},

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -296,9 +296,7 @@ do_select(SQL, ?DDL{table = BucketType} = DDL) ->
                                        {ok, {new|existing, riak_kv_qry_buffers:qbuf_ref()} |
                                              undefined} |
                                        {error, any()}.
-maybe_create_query_buffer(?SQL_SELECT{'ORDER BY' = [],
-                                      'LIMIT'    = [],
-                                      'OFFSET'   = []},
+maybe_create_query_buffer(?SQL_SELECT{'ORDER BY' = []},
                           _NSubQueries, _CompiledSelect, _CompiledOrderBy, _Options) ->
     {ok, undefined};
 maybe_create_query_buffer(SQL, NSubqueries, CompiledSelect, CompiledOrderBy, Options) ->

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -387,13 +387,15 @@ compile_select_clause(DDL, Options, ?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{c
     IsAggregate = sets:is_element(aggregate, ResultTypeSet),
     if
         IsGroupBy ->
-            Sel2 = Sel1#riak_sel_clause_v1{calc_type = group_by};
+            Sel2 = Sel1#riak_sel_clause_v1{
+                    calc_type = group_by,
+                    initial_state = {group_by, Sel1#riak_sel_clause_v1.initial_state, dict:new()}};
         IsAggregate ->
             Sel2 = Sel1#riak_sel_clause_v1{calc_type = aggregate};
         not IsAggregate ->
             Sel2 = Sel1#riak_sel_clause_v1{
-                   calc_type = rows,
-                   initial_state = []}
+                    calc_type = rows,
+                    initial_state = []}
     end,
     case Errors of
         [] ->

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -367,7 +367,7 @@ add_subquery_result(SubQId, {selected, Chunk}, #state{sub_qrys = SubQs,
     end.
 
 %% FIXME major hack, need to get rid of the estimation stuff
-chunk_length([_|_] = Chunk) -> length(Chunk);
+chunk_length(Chunk) when is_list(Chunk) -> length(Chunk);
 chunk_length({group_by,_,Dict}) -> dict:size(Dict).
 
 %%

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -365,27 +365,27 @@ add_subquery_result(SubQId, Chunk, #state{sub_qrys = SubQs,
     end.
 
 %%
-run_select_on_chunk(SubQId, Chunk, #state{qry = Query,
-                                          result = QueryResult1,
-                                          qbuf_ref = QBufRef}) ->
-
+run_select_on_chunk(SubQId, {selected, Chunk}, #state{qry = Query,
+                                                      result = QueryResult1,
+                                                      qbuf_ref = _QBufRef}) ->
     %% Return decoded_results for this chunk.  We delegate this to a
     %% helper function that determines whether the results have
     %% already been decoded by the sending vnode
 
-    DecodedChunk = get_decoded_results(Chunk),
+    % DecodedChunk = get_decoded_results(Chunk),
 
-    SelClause = sql_select_clause(Query),
+    % SelClause = sql_select_clause(Query),
     case sql_select_calc_type(Query) of
         rows ->
-            run_select_on_rows_chunk(SubQId, SelClause, DecodedChunk, QueryResult1, QBufRef);
-        aggregate ->
-            %% query buffers don't enter at this stage: QueryResult is always a
-            %% single row for aggregate SELECTs
-            run_select_on_aggregate_chunk(SelClause, DecodedChunk, QueryResult1);
-        group_by ->
-            %% ditto
-            run_select_on_group(Query, SelClause, DecodedChunk, QueryResult1)
+            [{SubQId, Chunk} | QueryResult1]
+            % run_select_on_rows_chunk(SubQId, SelClause, DecodedChunk, QueryResult1, QBufRef);
+        % aggregate ->
+        %     %% query buffers don't enter at this stage: QueryResult is always a
+        %     %% single row for aggregate SELECTs
+        %     run_select_on_aggregate_chunk(SelClause, DecodedChunk, QueryResult1);
+        % group_by ->
+        %     %% ditto
+        %     run_select_on_group(Query, SelClause, DecodedChunk, QueryResult1)
     end.
 
 %% ------------------------------------------------------------
@@ -397,85 +397,85 @@ run_select_on_chunk(SubQId, Chunk, #state{qry = Query,
 %%   if not, decodes and returns
 %% ------------------------------------------------------------
 
-get_decoded_results({decoded, Chunk}) ->
-    Chunk;
-get_decoded_results(Chunk) ->
-    decode_results(lists:flatten(Chunk)).
+% get_decoded_results({decoded, Chunk}) ->
+%     Chunk;
+% get_decoded_results(Chunk) ->
+%     decode_results(lists:flatten(Chunk)).
 
-rows_in_chunk({decoded, Chunk}) ->
+rows_in_chunk({_, Chunk}) ->
     length(Chunk);
 rows_in_chunk(Chunk) ->
     length(Chunk).
 
 
 %%
-run_select_on_group(Query, SelClause, Chunk, QueryResult1) ->
-    lists:foldl(
-        fun(Row, Acc) ->
-            run_select_on_group_row(Query, SelClause, Row, Acc)
-        end, QueryResult1, Chunk).
+% run_select_on_group(Query, SelClause, Chunk, QueryResult1) ->
+%     lists:foldl(
+%         fun(Row, Acc) ->
+%             run_select_on_group_row(Query, SelClause, Row, Acc)
+%         end, QueryResult1, Chunk).
 
-%%
-run_select_on_group_row(Query, SelClause, Row, QueryResult1) ->
-    {group_by, InitialGroupState, Dict1} = QueryResult1,
-    Key = select_group(Query, Row),
-    Aggregate1 =
-        case dict:find(Key, Dict1) of
-            error ->
-                prepare_group_by_initial_state(Row, InitialGroupState);
-            {ok, AggregateX} ->
-                AggregateX
-        end,
-    Aggregate2 = riak_kv_qry_compiler:run_select(SelClause, Row, Aggregate1),
-    Dict2 = dict:store(Key, Aggregate2, Dict1),
-    {group_by, InitialGroupState, Dict2}.
+% %%
+% run_select_on_group_row(Query, SelClause, Row, QueryResult1) ->
+%     {group_by, InitialGroupState, Dict1} = QueryResult1,
+%     Key = select_group(Query, Row),
+%     Aggregate1 =
+%         case dict:find(Key, Dict1) of
+%             error ->
+%                 prepare_group_by_initial_state(Row, InitialGroupState);
+%             {ok, AggregateX} ->
+%                 AggregateX
+%         end,
+%     Aggregate2 = riak_kv_qry_compiler:run_select(SelClause, Row, Aggregate1),
+%     Dict2 = dict:store(Key, Aggregate2, Dict1),
+%     {group_by, InitialGroupState, Dict2}.
 
-prepare_group_by_initial_state(Row, InitialState) ->
-    [prepare_group_by_initial_state2(Row, Col) || Col <- InitialState].
+% prepare_group_by_initial_state(Row, InitialState) ->
+%     [prepare_group_by_initial_state2(Row, Col) || Col <- InitialState].
 
-prepare_group_by_initial_state2(Row, InitFn) when is_function(InitFn) ->
-    InitFn(Row);
-prepare_group_by_initial_state2(_, InitVal) ->
-    InitVal.
+% prepare_group_by_initial_state2(Row, InitFn) when is_function(InitFn) ->
+%     InitFn(Row);
+% prepare_group_by_initial_state2(_, InitVal) ->
+%     InitVal.
 
-%%
-select_group(Query, Row) ->
-    GroupByFields = sql_select_group_by(Query),
-    select_group2(GroupByFields, Row).
+% %%
+% select_group(Query, Row) ->
+%     GroupByFields = sql_select_group_by(Query),
+%     select_group2(GroupByFields, Row).
 
-select_group2([], _) ->
-    [];
-select_group2([{N,_}|Tail], Row) when is_integer(N) ->
-    [lists:nth(N, Row)|select_group2(Tail, Row)];
-select_group2([{GroupByTimeFn,_}|Tail], Row) when is_function(GroupByTimeFn) ->
-    [GroupByTimeFn(Row)|select_group2(Tail, Row)].
+% select_group2([], _) ->
+%     [];
+% select_group2([{N,_}|Tail], Row) when is_integer(N) ->
+%     [lists:nth(N, Row)|select_group2(Tail, Row)];
+% select_group2([{GroupByTimeFn,_}|Tail], Row) when is_function(GroupByTimeFn) ->
+%     [GroupByTimeFn(Row)|select_group2(Tail, Row)].
 
-%% Run the selection clause on results that accumulate rows
-run_select_on_rows_chunk(SubQId, SelClause, DecodedChunk, QueryResult1, undefined) ->
-    IndexedChunks =
-        [riak_kv_qry_compiler:run_select(SelClause, Row) || Row <- DecodedChunk],
-    [{SubQId, IndexedChunks} | QueryResult1];
-run_select_on_rows_chunk(_SubQId, SelClause, DecodedChunk, _QueryResult1, QBufRef) ->
-    IndexedChunks =
-        [riak_kv_qry_compiler:run_select(SelClause, Row) || Row <- DecodedChunk],
-    try riak_kv_qry_buffers:batch_put(QBufRef, IndexedChunks) of
-        ok ->
-            ok;
-        {error, Reason} ->
-            throw({qbuf_internal_error, Reason})
-    catch
-        Error:Reason ->
-            lager:warning("Failed to send data to qbuf ~p serving subquery ~p of ~p: ~p:~p",
-                          [QBufRef, _SubQId, SelClause, Error, Reason]),
-            throw({qbuf_internal_error, "qbuf manager died/restarted mid-query"})
-    end.
+% %% Run the selection clause on results that accumulate rows
+% run_select_on_rows_chunk(SubQId, SelClause, DecodedChunk, QueryResult1, undefined) ->
+%     IndexedChunks =
+%         [riak_kv_qry_compiler:run_select(SelClause, Row) || Row <- DecodedChunk],
+%     [{SubQId, IndexedChunks} | QueryResult1];
+% run_select_on_rows_chunk(_SubQId, SelClause, DecodedChunk, _QueryResult1, QBufRef) ->
+%     IndexedChunks =
+%         [riak_kv_qry_compiler:run_select(SelClause, Row) || Row <- DecodedChunk],
+%     try riak_kv_qry_buffers:batch_put(QBufRef, IndexedChunks) of
+%         ok ->
+%             ok;
+%         {error, Reason} ->
+%             throw({qbuf_internal_error, Reason})
+%     catch
+%         Error:Reason ->
+%             lager:warning("Failed to send data to qbuf ~p serving subquery ~p of ~p: ~p:~p",
+%                           [QBufRef, _SubQId, SelClause, Error, Reason]),
+%             throw({qbuf_internal_error, "qbuf manager died/restarted mid-query"})
+%     end.
 
-%%
-run_select_on_aggregate_chunk(SelClause, DecodedChunk, QueryResult1) ->
-    lists:foldl(
-        fun(E, Acc) ->
-            riak_kv_qry_compiler:run_select(SelClause, E, Acc)
-        end, QueryResult1, DecodedChunk).
+% %%
+% run_select_on_aggregate_chunk(SelClause, DecodedChunk, QueryResult1) ->
+%     lists:foldl(
+%         fun(E, Acc) ->
+%             riak_kv_qry_compiler:run_select(SelClause, E, Acc)
+%         end, QueryResult1, DecodedChunk).
 
 %%
 -spec cancel_error_query(Error::any(), State1::#state{}) ->
@@ -578,12 +578,12 @@ prepare_final_results2(#riak_sel_clause_v1{col_return_types = ColTypes,
 sql_select_calc_type(?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{calc_type = Type}}) ->
     Type.
 
-%% Return the selection clause from a query
-sql_select_clause(?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{clause = Clause}}) ->
-    Clause.
+% %% Return the selection clause from a query
+% sql_select_clause(?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{compiled_clause = Clause}}) ->
+%     Clause.
 
-sql_select_group_by(?SQL_SELECT{ group_by = GroupBy }) ->
-    GroupBy.
+% sql_select_group_by(?SQL_SELECT{ group_by = GroupBy }) ->
+%     GroupBy.
 
 %%%===================================================================
 %%% Unit tests

--- a/src/riak_kv_select.erl
+++ b/src/riak_kv_select.erl
@@ -26,6 +26,8 @@
 -export([current_version/0]).
 -export([first_version/0]).
 -export([is_sql_select_record/1]).
+-export([run_merge_on_chunk/4]).
+-export([run_select_on_chunk/3]).
 
 -include("riak_kv_ts.hrl").
 
@@ -214,6 +216,128 @@ is_sql_select_record(#riak_select_v1{ }) -> true;
 is_sql_select_record(#riak_select_v2{ }) -> true;
 is_sql_select_record(#riak_select_v3{ }) -> true;
 is_sql_select_record(_)                  -> false.
+
+%%
+run_select_on_chunk(Chunk, ?SQL_SELECT{} =  Query, Acc) ->
+    case sql_select_calc_type(Query) of
+        rows ->
+            run_select_on_rows_chunk(sql_select_clause(Query), Chunk, undefined);
+        aggregate ->
+            run_select_on_aggregate_chunk(sql_select_clause(Query), Chunk, Acc);
+        group_by ->
+            run_select_on_group(Query, sql_select_clause(Query), Chunk, Acc)
+    end.
+
+%% ------------------------------------------------------------
+%% Helper function to return decoded query results for the current
+%% Chunk:
+%%
+%%   if already decoded, simply returns the decoded data
+%%
+%%   if not, decodes and returns
+%% ------------------------------------------------------------
+
+% rows_in_chunk({_, Chunk}) ->
+%     length(Chunk);
+% rows_in_chunk(Chunk) ->
+%     length(Chunk).
+
+
+%%
+run_select_on_group(Query, SelClause, Chunk, QueryResult1) ->
+    lists:foldl(
+        fun(Row, Acc) ->
+            run_select_on_group_row(Query, SelClause, Row, Acc)
+        end, QueryResult1, Chunk).
+
+%%
+run_select_on_group_row(Query, SelClause, Row, QueryResult1) ->
+    {group_by, InitialGroupState, Dict1} = QueryResult1,
+    Key = select_group(Query, Row),
+    Aggregate1 =
+        case dict:find(Key, Dict1) of
+            error ->
+                prepare_group_by_initial_state(Row, InitialGroupState);
+            {ok, AggregateX} ->
+                AggregateX
+        end,
+    Aggregate2 = riak_kv_qry_compiler:run_select(SelClause, Row, Aggregate1),
+    Dict2 = dict:store(Key, Aggregate2, Dict1),
+    {group_by, InitialGroupState, Dict2}.
+
+prepare_group_by_initial_state(Row, InitialState) ->
+    [prepare_group_by_initial_state2(Row, Col) || Col <- InitialState].
+
+prepare_group_by_initial_state2(Row, InitFn) when is_function(InitFn) ->
+    InitFn(Row);
+prepare_group_by_initial_state2(_, InitVal) ->
+    InitVal.
+
+%%
+select_group(Query, Row) ->
+    GroupByFields = sql_select_group_by(Query),
+    select_group2(GroupByFields, Row).
+
+select_group2([], _) ->
+    [];
+select_group2([{N,_}|Tail], Row) when is_integer(N) ->
+    [lists:nth(N, Row)|select_group2(Tail, Row)];
+select_group2([{GroupByTimeFn,_}|Tail], Row) when is_function(GroupByTimeFn) ->
+    [GroupByTimeFn(Row)|select_group2(Tail, Row)].
+
+%% Run the selection clause on results that accumulate rows
+run_select_on_rows_chunk(SelClause, DecodedChunk, undefined) ->
+    [riak_kv_qry_compiler:run_select(SelClause, Row) || Row <- DecodedChunk];
+run_select_on_rows_chunk(SelClause, DecodedChunk, QBufRef) ->
+    IndexedChunks =
+        [riak_kv_qry_compiler:run_select(SelClause, Row) || Row <- DecodedChunk],
+    try riak_kv_qry_buffers:batch_put(QBufRef, IndexedChunks) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            throw({qbuf_internal_error, Reason})
+    catch
+        Error:Reason ->
+            lager:warning("Failed to send data to qbuf ~p serving subquery ~p of ~p: ~p:~p",
+                          [QBufRef, x, SelClause, Error, Reason]),
+            throw({qbuf_internal_error, "qbuf manager died/restarted mid-query"})
+    end.
+
+%%
+run_select_on_aggregate_chunk(SelClause, DecodedChunk, QueryResult1) ->
+    lists:foldl(
+        fun(E, Acc) ->
+            riak_kv_qry_compiler:run_select(SelClause, E, Acc)
+        end, QueryResult1, DecodedChunk).
+
+%%
+run_merge_on_chunk(SubQId, Chunk, Query, Acc) ->
+    case sql_select_calc_type(Query) of
+        rows ->
+            [{SubQId,Chunk}|Acc];
+        aggregate ->
+            run_merge_on_aggregate(sql_select_merge_fns(Query), Chunk, Acc);
+        group_by ->
+            todo
+    end.
+
+run_merge_on_aggregate([], [], []) ->
+    [];
+run_merge_on_aggregate([MergeFn|MergeTail], [Col|ColTail], [AccCol|Acc]) ->
+    [MergeFn(Col,AccCol)|run_merge_on_aggregate(MergeTail,ColTail,Acc)].
+
+sql_select_calc_type(?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{calc_type = Type}}) ->
+    Type.
+
+%% Return the selection clause from a query
+sql_select_clause(?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{compiled_clause = Clause}}) ->
+    Clause.
+
+sql_select_group_by(?SQL_SELECT{group_by = GroupBy}) ->
+    GroupBy.
+
+sql_select_merge_fns(?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{result_merger_fns = MergeFns}}) ->
+    MergeFns.
 
 %%%
 %%% TESTS

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1052,6 +1052,10 @@ handle_range_scan(Bucket, ItemFilter, Query1,
             ?SQL_SELECT{'SELECT' = Select,
                         'FROM' = BucketType,
                         'WHERE' = W,
+                        'OFFSET' = Offset,
+                        'LIMIT' = Limit,
+                        group_by = GroupBy,
+                        'ORDER BY' = OrderBy,
                         local_key = #key_v1{ast = LKAST}} = Query2,
             %% always rebuild the module name, do not use the name from the select
             %% record because it was built in a different node which may have a
@@ -1079,8 +1083,12 @@ handle_range_scan(Bucket, ItemFilter, Query1,
             %% convert the select record into a proplist so that the hanoidb
             %% backend does not have a dependency on the TS header files
             QueryProps = [{where, W},
-                      {local_key_ast, LKAST},
-                      {filter_predicate_fn, PredicateFn}],
+                          {offset, Offset},
+                          {limit, Limit},
+                          {group_by, GroupBy},
+                          {order_by, OrderBy},
+                          {local_key_ast, LKAST},
+                          {filter_predicate_fn, PredicateFn}],
             Query3 = Query2?SQL_SELECT{'SELECT' = Select#riak_sel_clause_v1{compiled_clause = SelClause}},
             ResultFun =
                 fun(Items) ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -981,7 +981,7 @@ handle_coverage_request(kv_sql_select_request,
     Bucket = riak_kv_requests:get_bucket(Req),
     Query = riak_kv_requests:get_query(Req),
     handle_range_scan(Bucket, ItemFilter, Query,
-                      FilterVNodes, Sender, State, fun range_scan_result_fun_ack/2);
+                      FilterVNodes, Sender, State);
 handle_coverage_request(kv_index_request, Req, FilterVNodes, Sender, State) ->
     Bucket = riak_kv_requests:get_bucket(Req),
     ItemFilter = riak_kv_requests:get_item_filter(Req),
@@ -1038,8 +1038,7 @@ handle_range_scan(Bucket, ItemFilter, Query1,
                   FilterVNodes, Sender,
                   State=#state{mod=Mod,
                                key_buf_size=DefaultBufSz,
-                               modstate=ModState},
-                  ResultFunFun) ->
+                               modstate=ModState}) ->
     {ok, Capabilities} = Mod:capabilities(Bucket, ModState),
     IndexBackend = lists:member(indexes, Capabilities),
     case IndexBackend of
@@ -1058,6 +1057,9 @@ handle_range_scan(Bucket, ItemFilter, Query1,
             %% different module name because of compile versions in mixed version
             %% clusters
             HelperMod = riak_ql_ddl:make_module_name(BucketType),
+            {_, Select} = riak_kv_qry_compiler:compile_select_clause_fns(
+                HelperMod:get_ddl(), Query2, riak_kv_qry_compiler:options()),
+            #riak_sel_clause_v1{compiled_clause = SelClause} = Select,
             PredicateFn =
                 case proplists:get_value(filter,W,[]) of
                     [] ->
@@ -1079,7 +1081,10 @@ handle_range_scan(Bucket, ItemFilter, Query1,
             Query3 = [{where, W},
                       {local_key_ast, LKAST},
                       {filter_predicate_fn, PredicateFn}],
-            ResultFun = ResultFunFun(Bucket, Sender),
+            ResultFun =
+                fun(Items) ->
+                    range_scan_result_fun_ack(Bucket, Sender, SelClause, Items)
+                end,
             BufSize = buffer_size_for_index_query(Query2, DefaultBufSz),
             Opts = [{index, Bucket, prepare_index_query(Query3)},
                     {bucket, Bucket}, {buffer_size, BufSize}],
@@ -2113,45 +2118,28 @@ result_fun_ack(Bucket, Sender) ->
 %% during debugging.
 %% ------------------------------------------------------------
 
-range_scan_result_fun_ack(Bucket, Sender) ->
-    fun(Items) ->
-	    range_scan_result_fun_ack(Bucket, Sender, Items)
-    end.
-
-range_scan_result_fun_ack(Bucket, Sender, Items) ->
+range_scan_result_fun_ack(Bucket, Sender, SelClause, Items) ->
     Monitor = riak_core_vnode:monitor(Sender),
-
-    %% Check capabilities.  If upgraded, decode the results
-    %% here.  If mixed, delegate decoding to the coordinator,
-    %% as before
-    
-    case riak_core_capability:get({riak_kv, decode_query_results_at_vnode}) of
-	true ->
-	    DecodedItems = riak_kv_qry_worker:decode_results(lists:flatten(Items)),
-	    
-	    %% Instead of simply sending DecodedItems as the
-	    %% payload, we send a tuple indicating that the
-	    %% items have already been decoded.  This allows
-	    %% the receiver to distinguish between results
-	    %% that have already been decoded by the vnode
-	    %% (new behavior indicated by {riak_kv,
-	    %% sql_select_decode_results} capability), and
-	    %% results that have not (TS behavior prior to
-	    %% this change)
-	    
-	    riak_core_vnode:reply(Sender, {{self(), Monitor}, Bucket, {decoded, DecodedItems}});
-	_ ->
-	    riak_core_vnode:reply(Sender, {{self(), Monitor}, Bucket, Items})
-    end,
-    
+    %% Instead of simply sending DecodedItems as the
+    %% payload, we send a tuple indicating that the
+    %% items have already been decoded.  This allows
+    %% the receiver to distinguish between results
+    %% that have already been decoded by the vnode
+    %% (new behavior indicated by {riak_kv,
+    %% sql_select_decode_results} capability), and
+    %% results that have not (TS behavior prior to
+    %% this change)
+    DecodedItems = riak_kv_qry_worker:decode_results(lists:flatten(Items)),
+    SelectedItems = [riak_kv_qry_compiler:run_select(SelClause, Row) || Row <- DecodedItems],    
+    riak_core_vnode:reply(Sender, {{self(), Monitor}, Bucket, {selected, SelectedItems}}),
     receive
-	{Monitor, ok} ->
-	    erlang:demonitor(Monitor, [flush]);
-	{Monitor, stop_fold} ->
-	    erlang:demonitor(Monitor, [flush]),
-	    throw(stop_fold);
-	{'DOWN', Monitor, process, _Pid, _Reason} ->
-	    throw(receiver_down)
+        {Monitor, ok} ->
+            erlang:demonitor(Monitor, [flush]);
+        {Monitor, stop_fold} ->
+            erlang:demonitor(Monitor, [flush]),
+            throw(stop_fold);
+            {'DOWN', Monitor, process, _Pid, _Reason} ->
+            throw(receiver_down)
     end.
 
 %% @doc If a listkeys request sends a result of `{From, Bucket,


### PR DESCRIPTION
Depends on
* riak_kv_hanoidb_backend: https://github.com/andytill/riak_kv_hanoidb_backend/pull/1
* riak_ql: https://github.com/andytill/riak_ql/pull/2

Before this change, each row was transmitted from the vnode to the query coordinator, the select clause would be executed on the coordinator as the chunks came in.

This change makes the vnodes execute the select clause. This has the benefit that execution is parallelised among vnodes rather than done on the single coordinator, and the result of the select clause can be significantly smaller than the result set.

Main changes:
* The vnode must use the select clause AST to build the "compiled" select clause erlang funs which will be executed over the row. The transmitted funs cannot be used because if the modules across two nodes do not hash identically then an exception is thrown when that fun is called.
* The compiled select clause is executed on each row on the vnode.
* The coordinator assumes all chunk results are decoded.
* The coordinator now runs a "merge" on results from each chunk.
* The functions for executing the select clause have been moved from the `riak_kv_qry_worker` module to the `riak_kv_select` module.
* vnodes return `LIMIT + OFFSET` rows as long as there is no `ORDER BY ` or `GROUP BY` clause in the query. The coordinator then applies the offset and limit to the final result merged from all the sub queries. This means that what the vnodes return individually is no larger than the final result.
* Temporary tables are not used to calculate limit and offset.
* A query with a `LIMIT` clause and no `GROUP BY` or `ORDER BY` clauses will return early if it accumulates the required number of rows.